### PR TITLE
タスクの削除機能の実装 #8

### DIFF
--- a/frontend/src/components/TodoListComponent.vue
+++ b/frontend/src/components/TodoListComponent.vue
@@ -7,7 +7,7 @@
                 <div class="task-container" v-for="task in undone_tasks" :key="task.id">
                     <button class="checkbox" @click="updateTask(task.id)"></button>
                     <span class="task-title">{{ task.title }}</span>
-                    <button class="delete-btn" @click="showConfirmModal()">&#9003;</button>
+                    <button class="delete-btn" @click="showConfirmModal(task.id)">&#9003;</button>
                 </div>
                 <button class="add-btn">&plus;</button>
             </div>
@@ -24,7 +24,7 @@
                         <br>
                         <span class="datetime">{{ '(' + formatDatetime(task.updated_at) + ')' }}</span>
                     </div>
-                    <button class="delete-btn" @click="showConfirmModal()">&#9003;</button>
+                    <button class="delete-btn" @click="showConfirmModal(task.id)">&#9003;</button>
                 </div>
             </div>
         </div>
@@ -51,6 +51,7 @@ export default {
             undone_tasks: [],
             done_tasks: [],
             showModal: false,
+            delete_id: null,
         };
     },
     mounted() {
@@ -77,14 +78,17 @@ export default {
                 }
             });
         },
+        resetTasks() {
+            this.done_tasks = [];
+            this.undone_tasks = [];
+            this.getTasks();
+        },
         // タスクを更新
         updateTask(task_id) {
             axios.post(this.base_url + task_id + '/update').then(response => {
                 // 更新後のデータを取得し表示データをリセット
                 if (response.data) {
-                    this.done_tasks = [];
-                    this.undone_tasks = [];
-                    this.getTasks();
+                    this.resetTasks();
                 }
             })
             .catch(error => {
@@ -96,15 +100,26 @@ export default {
             return moment(datetime).format('YYYY-MM-DD HH:mm');
         },
         // 削除確認モーダルを表示
-        showConfirmModal() {
+        showConfirmModal(task_id) {
             this.showModal = true;
+            this.delete_id = task_id;
         },
         // 削除確認モーダル内の選択をもとに処理
         confirmDelete(is_confirmed) {
             if (is_confirmed) {
                 // 削除APIを実行
+                axios.post(this.base_url + this.delete_id + '/delete').then(response => {
+                    // 更新後のデータを取得し表示データをリセット
+                    if (response.data) {
+                        this.resetTasks();
+                    }
+                })
+                .catch(error => {
+                    console.error(error);
+                });
             }
             this.showModal = false;
+            this.delete_id = null;
         },
     },
 };

--- a/frontend/src/components/TodoListComponent.vue
+++ b/frontend/src/components/TodoListComponent.vue
@@ -7,7 +7,7 @@
                 <div class="task-container" v-for="task in undone_tasks" :key="task.id">
                     <button class="checkbox" @click="updateTask(task.id)"></button>
                     <span class="task-title">{{ task.title }}</span>
-                    <button class="delete-btn">&#9003;</button>
+                    <button class="delete-btn" @click="showConfirmModal()">&#9003;</button>
                 </div>
                 <button class="add-btn">&plus;</button>
             </div>
@@ -24,24 +24,33 @@
                         <br>
                         <span class="datetime">{{ '(' + formatDatetime(task.updated_at) + ')' }}</span>
                     </div>
-                    <button class="delete-btn">&#9003;</button>
+                    <button class="delete-btn" @click="showConfirmModal()">&#9003;</button>
                 </div>
             </div>
         </div>
+
+        <confirm-modal
+            :action_name="'削除'"
+            v-show="showModal"
+            @confirm-method="confirmDelete"
+        ></confirm-modal>
     </div>
 </template>
 
 <script>
 import axios from 'axios';
 import moment from "moment";
+import confirmModal from './confirmModal.vue';
 
 export default {
+    components: { confirmModal },
     data() {
         return {
             base_url: 'http://localhost:8000/api/',
             tasks: [],
             undone_tasks: [],
             done_tasks: [],
+            showModal: false,
         };
     },
     mounted() {
@@ -85,6 +94,17 @@ export default {
         // 日時をフォーマット化
         formatDatetime(datetime) {
             return moment(datetime).format('YYYY-MM-DD HH:mm');
+        },
+        // 削除確認モーダルを表示
+        showConfirmModal() {
+            this.showModal = true;
+        },
+        // 削除確認モーダル内の選択をもとに処理
+        confirmDelete(is_confirmed) {
+            if (is_confirmed) {
+                // 削除APIを実行
+            }
+            this.showModal = false;
         },
     },
 };

--- a/frontend/src/components/confirmModal.vue
+++ b/frontend/src/components/confirmModal.vue
@@ -1,0 +1,87 @@
+<template>
+    <div>
+        <div class="modal">
+            <p class="modal-message">{{ '本当に' + action_name + 'しますか？' }}</p>
+            <div class="btn-container">
+                <span class="modal-cancel" @click="$emit('confirm-method', false)">
+                    いいえ
+                </span>
+                <button class="modal-btn" @click="$emit('confirm-method', true)">
+                    {{ action_name + 'する' }}
+                </button>
+            </div>
+        </div>
+        <div id="modal-overlay"></div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: ['action_name'],
+};
+</script>
+
+<style scoped>
+.modal {
+    background: white;
+    z-index: 2;
+    text-align: center;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 10px;
+    width: 50%;
+    height: 35%;
+    display: flex;
+    flex-flow: column;
+    justify-content: center;
+}
+
+.modal-message {
+    font-size: 20px;
+}
+
+.btn-container {
+    display: flex;
+    gap: 30px;
+    justify-content: center;
+    margin-top: 30px;
+}
+
+.modal-cancel {
+    border: solid 2px black;
+    border-radius: 3px;
+    margin-right: 30px;
+    transition: 0.4s;
+}
+
+.modal-cancel:hover {
+    cursor: pointer;
+    color: silver;
+}
+
+.modal-btn {
+    color: red;
+    border: solid 2px red;
+    border-radius: 3px;
+    transition: 0.4s;
+    background-color: white;
+}
+
+.modal-btn:hover {
+    background: red;
+    color: white;
+    cursor: pointer;
+}
+
+#modal-overlay {
+    z-index: 1;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.75);
+}
+</style>

--- a/laravel/app/Http/Controllers/TaskController.php
+++ b/laravel/app/Http/Controllers/TaskController.php
@@ -23,4 +23,12 @@ class TaskController extends Controller
 
         return response()->json($is_success);
     }
+
+    // タスクの削除
+    public function delete(int $id)
+    {
+        $delete_count = Task::destroy($id);
+
+        return response()->json($delete_count === 1);
+    }
 }

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -23,3 +23,4 @@ use App\Http\Controllers\TaskController;
 
 Route::get('/tasks', [TaskController::class, 'index']);
 Route::post('/{task_id}/update', [TaskController::class, 'update']);
+Route::post('/{task_id}/delete', [TaskController::class, 'delete']);


### PR DESCRIPTION
 - 削除確認モーダル表示機能の追加
 - 削除APIの作成、Vue側での実行処理の追加
 
### イメージ（タスク4を削除）
![image](https://github.com/kanetatsu-biz/Laravel-Vue-Docker-Tutorial/assets/123366737/b9b3ec51-72b2-4a79-8b2c-d13c3bb5c3a8)

![image](https://github.com/kanetatsu-biz/Laravel-Vue-Docker-Tutorial/assets/123366737/bd18c871-e582-4928-871a-266cd8f20644)

![image](https://github.com/kanetatsu-biz/Laravel-Vue-Docker-Tutorial/assets/123366737/d3425783-682c-4eb6-8f13-9d856fd9065e)
